### PR TITLE
replaced deprecated bindShared() with singleton()

### DIFF
--- a/src/Lookitsatravis/Listify/ListifyServiceProvider.php
+++ b/src/Lookitsatravis/Listify/ListifyServiceProvider.php
@@ -52,7 +52,7 @@ class ListifyServiceProvider extends ServiceProvider {
      */
     protected function registerListifyAttach()
     {
-        $this->app->bindShared('listify.attach', function($app)
+        $this->app->singleton('listify.attach', function($app)
         {
             return new Commands\AttachCommand;
         });


### PR DESCRIPTION
Since bindShared() is deprecated and has been removed in Laravel 5.2, using singleton() instead.