### PR TITLE
Bugfix: Move item to bottom of list on scope change

### DIFF
--- a/src/Lookitsatravis/Listify/Listify.php
+++ b/src/Lookitsatravis/Listify/Listify.php
@@ -612,10 +612,7 @@ trait Listify
      */
     private function addToListBottom()
     {
-        if($this->isNotInList())
-        {
-            $this->setListifyPosition($this->bottomPositionInList() + 1);
-        }
+        $this->setListifyPosition($this->bottomPositionInList() + 1);
     }
 
     /**


### PR DESCRIPTION
The `addToListBottom` function was only setting the new list position if the item was not already in the list. This created an issue when updating an existing record to have a new scope (via the `checkScope` function)... because the record already exists so it was already in the list, and hence it was never getting its position number updated within the new scope.

So I removed the `if($this->isNotInList())` check in the `addToListBottom` function, and it works now.